### PR TITLE
Fix text comparison so that 'Remove' is no longer needed.

### DIFF
--- a/app.js
+++ b/app.js
@@ -38,7 +38,11 @@ list.addEventListener('click', function(event) {
     // If button is clicked on, remove it
     if (event.target.tagName === 'BUTTON') {
         let existingTodos = JSON.parse(localStorage.getItem("todos")) || [];
-        const updatedTodos = removeItemFromArray(existingTodos, event.target.parentElement.innerText)
+
+        // Since we added a span to differentiate between the todo and the button,
+        // we can use the previousSibling property to get the todo text without 'Remove'
+        const todoText = event.target.previousSibling.innerText
+        const updatedTodos = removeItemFromArray(existingTodos, todoText)
         localStorage.setItem("todos", JSON.stringify(updatedTodos));
         event.target.parentElement.remove()
     }
@@ -53,9 +57,7 @@ function removeItemFromArray(arr, todo) {
     let result = []
 
     for (let item of arr) {
-        // Why is it adding 'Remove' to the end of the todo string?
-        let addRemoveString = item + 'Remove'
-        if (addRemoveString !== todo) {
+        if (item !== todo){
             result.push(item)
         }
     }
@@ -66,13 +68,18 @@ function addMarkupToDOM(input){
     const newTodo = document.createElement('li')
     // Create element button
     const removeBtn = document.createElement('button')
+
+    // Creating a span element to differentiate between the todo itself and the button
+    const span = document.createElement('span')
     // .value retrieves the current value of an input field in a form
+
     // innerText sets the newTodo value
-    newTodo.innerText = input
+    span.innerText = input
     // Set innerText of button element to 'Remove'
     removeBtn.innerText = 'Remove'
     // Append list item to unordered list
     list.append(newTodo)
     // Append the element as the last child of an element, in other words, to the li element
-    newTodo.appendChild(removeBtn)
+    newTodo.append(span)
+    newTodo.append(removeBtn)
 }


### PR DESCRIPTION
## Summary
To fix the problem where the button text, `Remove`, was being added to each TODO text, I placed the TODO text in a `<span>` and then appended that to the `<li>`. This gives us two separate elements, each with their own properties, that live inside of the `<li>` itself.

Following this, in `list.addEventListener`, I pulled the actual TODO text from `event.target.previousSibling.innerText`, which is the text of the newly added `<span>` element only.

I then passed this string, stored as `todoText`, into our comparison function, called `removeItemFromArray()`.

Finally, I modified `removeItemFromArray()` by taking out the extra section needed to compare the `text + 'Remove'`.


## Testing Done
Manual testing. To test, I:
- Added TODOs
- Refreshed the page to ensure they were still there.
- Removed TODOs to make sure they were removed from the DOM, and that the correct ones were removed
- Refreshed the page to ensure that only the non-removed TODOs would still load on page load.

Please see the video below for an example:

https://github.com/jessicanoya/Springboard-TODO-App/assets/40155298/4e589a0f-0234-4d81-b0c7-488e6bfd0674

